### PR TITLE
Move 'data' to a simple_property for actions.Submit. Call .to_dict() …

### DIFF
--- a/pyadaptivecards/abstract_components.py
+++ b/pyadaptivecards/abstract_components.py
@@ -91,7 +91,9 @@ class Serializable:
         for sp in self.simple_properties:
             o = getattr(self, sp, None)
 
-            if o is not None:
+            if getattr(o, 'to_dict', None):
+                export[sp] = o.to_dict()
+            elif o is not None:
                 export[sp] = o
 
         # Export all complex properties by calling its respective serialization

--- a/pyadaptivecards/actions.py
+++ b/pyadaptivecards/actions.py
@@ -61,8 +61,8 @@ class Submit(Serializable):
         self.title = title
         self.iconURL = iconURL
 
-        super().__init__(serializable_properties=['data'],
-                         simple_properties=['title', 'iconURL', 'type'])
+        super().__init__(serializable_properties=[],
+                         simple_properties=['data', 'title', 'iconURL', 'type'])
 
 class ShowCard(Serializable):
     """Shows the specified adaptive card when this action/button is clicked."""


### PR DESCRIPTION
Fix for #5 

When there's a simple_property and it is an object, call the .to_dict() on that object versus passing the object directly. Also fixes the Submit action to properly render as well.