### PR TITLE
Fix options handling. Finish check_type() for components

### DIFF
--- a/pyadaptivecards/components.py
+++ b/pyadaptivecards/components.py
@@ -23,9 +23,12 @@ SOFTWARE.
 """
 
 from .abstract_components import Serializable
-from .utils import check_type
-from .options import BlockElementHeight, Spacing, ImageSize, ImageStyle, Colors, FontSize, ContainerStyle
 from .actions import OpenUrl, ShowCard, Submit
+from .options import (BlockElementHeight, Colors, ContainerStyle, FontSize,
+                      FontWeight, HorizontalAlignment, ImageSize, ImageStyle,
+                      Spacing, VerticalContentAlignment)
+from .utils import check_type
+
 
 class MediaSource(Serializable):
     """Defines the source of a Media element."""
@@ -132,7 +135,7 @@ class Image(Serializable):
         check_type(altText, str, False, True)
         check_type(backgroundColor, str, False, True)
         check_type(height, (str, BlockElementHeight), False, True)
-        check_type(horizontalAlignment, horizontalAlignment, False, True)
+        check_type(horizontalAlignment, HorizontalAlignment, False, True)
         check_type(selectAction, (OpenUrl, Submit), False, True)
         check_type(size, ImageSize, False, True)
         check_type(style, ImageStyle, False, True)
@@ -183,7 +186,7 @@ class TextBlock(Serializable):
             color(Colors): The color of the text.
             horizontalAlignment(HorizontalAlignment): Controls how the component
                 is positioned within its parent.
-            isSubtle(bool): If true, displays text slightly toned down to appear 
+            isSubtle(bool): If true, displays text slightly toned down to appear
                 less prominent.
             maxLines(int): Specifies the number of lines to display.
             size(FontSize): Controls the size of the text.
@@ -198,6 +201,15 @@ class TextBlock(Serializable):
         #ToDo(mneiding): Type check
         check_type(text, str, False, False)
         check_type(color, Colors, False, True)
+        check_type(horizontalAlignment, HorizontalAlignment, False, True)
+        check_type(isSubtle, bool, False, True)
+        check_type(maxLines, int, False, True)
+        check_type(size, FontSize, False, True)
+        check_type(weight, FontWeight, False, True)
+        check_type(wrap, bool, False, True)
+        check_type(separator, bool, False, True)
+        check_type(spacing, Spacing, False, True)
+        check_type(id, str, False, True)
 
         self.type = "TextBlock"
         self.text = text
@@ -220,8 +232,8 @@ class TextBlock(Serializable):
                         ])
 
 class Column(Serializable):
-    """A column contains other components and (together with a ColumnSet) allows to display 
-        multiple components under each other. 
+    """A column contains other components and (together with a ColumnSet) allows to display
+        multiple components under each other.
     """
     def __init__(self, items=None,
                        separator=None,
@@ -242,10 +254,18 @@ class Column(Serializable):
             style(ContainerStyle): The style of this column.
             verticalContentAlignment(VerticalContentAlignment): The vertical alignment of the column
                 content.
-            width(str, int): The width of this column. Can be "auto", "stretch" or a number that 
+            width(str, int): The width of this column. Can be "auto", "stretch" or a number that
                 represents the width in pixels.
-            id(str): The id of this component. 
+            id(str): The id of this component.
         """
+        check_type(separator, bool, False, True)
+        check_type(spacing, Spacing, False, True)
+        check_type(selectAction, (OpenUrl, Submit), False, True)
+        check_type(style, (str, ContainerStyle), False, True)
+        check_type(verticalContentAlignment, VerticalContentAlignment, False, True)
+        check_type(width, str, False, True)
+        check_type(id, str, False, True)
+
         self.type = "Column"
         self.items = items
         self.separator = separator
@@ -263,15 +283,18 @@ class Column(Serializable):
                          ])
 
 class Fact(Serializable):
-    """Fact component to display a set of facts. 
+    """Fact component to display a set of facts.
     """
     def __init__(self, title, value):
         """Create a new Fact.
-        
+
         Args:
             title(str): The title of this fact
             value(str): The value of this fact
         """
+        check_type(title, str, False, False)
+        check_type(value, str, False, False)
+
         self.title = title
         self.value = value
 
@@ -279,17 +302,20 @@ class Fact(Serializable):
                          simple_properties=['title', 'value'])
 
 class Choice(Serializable):
-    """Choice component. 
+    """Choice component.
 
-    Can be used together with a ChoiceSet to display different choices. 
+    Can be used together with a ChoiceSet to display different choices.
     """
     def __init__(self, title, value):
-        """Create a new choice. 
+        """Create a new choice.
 
         Args:
             title(str): The title of the choice
             value(str): The value of the choice
         """
+        check_type(title, str, False, False)
+        check_type(value, str, False, False)
+
         self.title = title
         self.value = value
 

--- a/pyadaptivecards/options.py
+++ b/pyadaptivecards/options.py
@@ -24,7 +24,8 @@ SOFTWARE.
 
 from enum import Enum
 
-class AbstractOption(Enum):
+
+class AbstractOption(str, Enum):
     def to_value(self):
         return str(self.name).lower()
 
@@ -34,88 +35,88 @@ class AbstractOption(Enum):
     def __repr__(self):
         return self.to_value()
 
-class VerticalContentAlignment:
-    """Specifies the vertical alignment of a component or of components in a 
+class VerticalContentAlignment(AbstractOption):
+    """Specifies the vertical alignment of a component or of components in a
     container.
     """
-    TOP = 1
-    CENTER = 2
-    BOTTOM = 3
+    TOP = 'top'
+    CENTER = 'center'
+    BOTTOM = 'bottom'
 
 class Colors(AbstractOption):
     """Specifies the color of a textblock"""
-    DEFAULT = 1
-    DARK = 2
-    LIGHT = 3
-    ACCENT = 4
-    GOOD = 5
-    WARNING = 6
-    ATTENTION = 7
+    DEFAULT = 'default'
+    DARK = 'dark'
+    LIGHT = 'light'
+    ACCENT = 'accent'
+    GOOD = 'good'
+    WARNING = 'warning'
+    ATTENTION = 'attention'
 
 class HorizontalAlignment(AbstractOption):
     """Specifies the horizontal alignment of a component"""
-    LEFT = 1
-    CENTER = 2
-    RIGHT = 3
+    LEFT = 'left'
+    CENTER = 'center'
+    RIGHT = 'right'
 
 class FontSize(AbstractOption):
     """Specifies the font size of a TextBlock"""
-    DEFAULT = 1
-    SMALL = 2
-    MEDIUM = 3
-    LARGE = 4
-    EXTRALARGE = 5
+    DEFAULT = 'default'
+    SMALL = 'small'
+    MEDIUM = 'medium'
+    LARGE = 'large'
+    EXTRALARGE = 'extralarge'
 
 class FontWeight(AbstractOption):
     """Specifies the font weight of a TextBlock"""
-    DEFAULT = 1
-    LIGHTER = 2
-    BOLDER = 3
+    DEFAULT = 'default'
+    LIGHTER = 'lighter'
+    BOLDER = 'bolder'
 
 class BlockElementHeight(AbstractOption):
     """Specifies the way the height of a element is determined. """
-    AUTO = 1
-    STRETCH = 2
+    AUTO = 'auto'
+    STRETCH = 'stretch'
 
 class Spacing(AbstractOption):
     """Specify the spacing around a component"""
-    DEFAULT = 1
-    NONE = 2
-    SMALL = 3
-    MEDIUM = 4
-    LARGE = 5
-    EXTRALARGE = 6
-    PADDING = 7
+    DEFAULT = 'default'
+    NONE = 'none'
+    SMALL = 'small'
+    MEDIUM = 'medium'
+    LARGE = 'large'
+    EXTRALARGE = 'extralarge'
+    PADDING = 'padding'
 
 class ImageSize(AbstractOption):
     """Specify the size scaling of a Image"""
-    AUTO = 1
-    STRETCH = 2
-    SMALL = 3
-    MEDIUM = 4
-    LARGE = 5
+    AUTO = 'auto'
+    STRETCH = 'stretch'
+    SMALL = 'small'
+    MEDIUM = 'medium'
+    LARGE = 'large'
 
 class ImageStyle(AbstractOption):
-    """Specifies the style of the image. 
+    """Specifies the style of the image.
 
     PERSON will make the picture rounded
     """
-    DEFAULT = 1
-    PERSON = 2
+    DEFAULT = 'default'
+    PERSON = 'person'
 
 class ContainerStyle(AbstractOption):
     """Specifies the style of the container"""
-    DEFAULT = 1
-    EMPHASIS = 2
+    DEFAULT = 'default'
+    EMPHASIS = 'emphasis'
 
 class TextInputStyle(AbstractOption):
     """Specifies the type of input that a Text input can expect"""
-    TEXT = 1
-    TEL = 2
-    URL = 3
-    EMAIL = 4
+    TEXT = 'text'
+    TEL = 'tel'
+    URL = 'url'
+    EMAIL = 'email'
 
 class ChoiceInputStyle(AbstractOption):
     """Specifies the display style for a choice input"""
-    COMPACT = 1
-    EXPANDED = 2
+    COMPACT = 'compact'
+    EXPANDED = 'expanded'


### PR DESCRIPTION
I cleaned up the Options enum values to match what the spec expects.

While I was in there, I added some check_type() for classes I was using since you mentioned it was on your ToDo.

Lastly, my editor cleaned up trailing spaces and isort did its thing.